### PR TITLE
don't reuse file name if path is too long

### DIFF
--- a/video_extras_tab/process.py
+++ b/video_extras_tab/process.py
@@ -53,8 +53,9 @@ def process(taskId, pathIn, fps, pathOut, enableLivePreview, *args, **kwargs):
         run_postprocessing(*args, **kwargs)
 
         shared.state.textinfo = 'video saving'
-        print("generate done, generating video")
-        save_video_path = os.path.join(pathOut, f'output_{os.path.basename(pathIn)}_{timestamp}.mp4')
+        save_video_path = os.path.join(pathOut, f'output_{os.path.splitext((os.path.basename(pathIn)))[0]}_{timestamp}.mp4')
+        if len(save_video_path) > 260:
+            save_video_path = os.path.join(pathOut, f'output_{timestamp}.mp4')
         save_video(pathOut, fps_out, pathIn, save_video_path)
 
         return [], plaintext_to_html(f"Saved into {save_video_path}"), ''


### PR DESCRIPTION
```py
        save_video_path = os.path.join(pathOut, f'output_{os.path.basename(pathIn)}_{timestamp}.mp4')
```
hear you forgot to strip out the file extension
so you'll get output videos names like `output_video.mp4_timestamp.mp4`

I suggest in the future you use `pathlib.Path(r"path/of/file").stem`, more convenient and less chance of error

---

there's also the issue that I was unlucky enough to face all my first test which is that my file name is too long
which means the exporting a video always fails because "file is not found" <--- error message

I added a simple detection if length > 259 then use a shorete path

likely there are better ways of dealing with this, and they're like they are better ways of checking the path length limit
but I didn't bother

---

another issue that I think you should sort out

basically I believe you assume that the user will going to be using MP4 files but that is not the case
the problem is as I recall the command line you use only supports MP4

and I think you're specifying copying the the AAC audio
the issue is that not use AAC supports and if I'm correct that would break when using with other formats